### PR TITLE
Fix broken links from repo migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All events are scheduled via our [Meetup](http://www.meetup.com/Women-Who-Code-D
 
 ## What if I'm a first timer that's never coded before?
 
-Check out our Guide to [front end for first timers](https://github.com/womenwhocodedc/front-end-community/blob/master/learning-resources/front-end-hack-nights/first_timers_guide.md), that also contains information on how to learn about coding. Go through the recommended resources and ask lots of questions!
+Check out our Guide to [front end for first timers](https://github.com/womenwhocodedc/front-end-community/blob/master/first_timers_guide.md), that also contains information on how to learn about coding. Go through the recommended resources and ask lots of questions!
 
 ## What if I'm a web development pro?
 
@@ -65,10 +65,3 @@ This study group is intended to be exclusively open for any who identify as wome
 Happy coding! :) 
 
 ![alt tag](http://www.barbarianmeetscoding.com/images/i-know-javascript.jpg)
-
-
-
-
-
-
-

--- a/first_timers_guide.md
+++ b/first_timers_guide.md
@@ -305,13 +305,13 @@ Now that you've built your first web page, use Women Who Code DC's study groups 
 * [Dash](https://dash.generalassemb.ly/)
 * [CodeAcademy HTML & CSS](https://www.codecademy.com/learn/web)
 * [Khan Academy - HTML + CSS](https://www.khanacademy.org/computing/computer-programming/html-css)
-* [Learn JavaScript](https://github.com/womenwhocodedc/organization/blob/master/learning-resources/front-end-hack-nights/first_timers_javascript_guide.md)
+* [Learn JavaScript](https://github.com/womenwhocodedc/front-end-community/blob/master/first_timers_javascript_guide.md)
 * [Khan Academy - HTML + CSS + JS](https://www.khanacademy.org/computing/computer-programming/html-css-js)
 
 #### Front End Study Guides
 * [HTML Study Guide](https://github.com/womenwhocodedc/front-end-community/blob/master/html_study_guide.md)
-* [CSS Study Guide]()
-* [JavaScript Study Guide]()
+* [CSS Study Guide](https://github.com/womenwhocodedc/front-end-community/blob/master/CSS_study_guide.md)
+* [JavaScript Study Guide](https://github.com/womenwhocodedc/front-end-community/blob/master/javascript_study_guide.md)
 
 #### Keep in touch!
 * Come to our [Meetups](http://www.meetup.com/Women-Who-Code-DC/).

--- a/first_timers_javascript_guide.md
+++ b/first_timers_javascript_guide.md
@@ -215,15 +215,15 @@ Congratulations! Your well on your way to becoming a programmer.
 
 ### Okay, what next?
 
-The only logical next step is to **NOT STOP!** Check out our [learning resources](#) section and continue your journey. All the best and congratulations!
+The only logical next step is to **NOT STOP!** Check out our [learning resources](https://github.com/womenwhocodedc/front-end-community/blob/master/first_timers_javascript_guide.md#resources) section and continue your journey. All the best and congratulations!
 
 Remember, even though we did access your page via a web browser, it's not actually on the Internet! For that you would need to
 [host](http://en.wikipedia.org/wiki/Web_hosting_service) your page online. That's an advanced topic that shouldn't worry about right now!
 
 ### Resources?
 
-* [Front End Hack Night Resource List](#)
-* [Git Guide](#)
+* [JavaScript Study Guide](https://github.com/womenwhocodedc/front-end-community/blob/master/javascript_study_guide.md)
+* [Front End Resources](https://github.com/womenwhocodedc/front-end-community/blob/master/front_end_guide.md)
 * [Intro to JS](http://nupurkapoor.github.io/js-study-group/#/)
 * [Intro to Git and Github](http://nupurkapoor.github.io/intro-to-git/#/)
 * We use [Slack](https://slack.com/) as our internal chat system! To understand Slack better check out the [Slack guide](https://github.com/womenwhocodedc/organization/blob/master/slack_guide.md).


### PR DESCRIPTION
/cc @kdmcclin @womenwhocodedc/front-end-leads 

Some of the links in README.md, first_timers_guide.md and first_timers_javascript_guide.md broke after migrating from /organization to /front-end-community.

Fixes https://github.com/womenwhocodedc/front-end-community/issues/3.

Also removed some extra whitespace from the bottom of README.md.
