### PR TITLE
FE Repo Updates

### DIFF
--- a/events/checklist.md
+++ b/events/checklist.md
@@ -1,1 +1,21 @@
-# Front End Hack Night Checklist
+# Front End Lab Checklist/Guidance
+For special events such as tech talks, panels, etc. outside of usual lab nights (or first timers nights)
+
+## To-Do's
+* Secure a date, time, and venue (regular Monday nights or Thursday nights are best for language events)
+ * Coordinate with Su for hosts/refreshments information
+* Post an event on Meetup page
+ * Check maximum capacity of venue and enforce limit on Meetup event
+ * Respond to comments promptly
+* Confirm who will be participating in the event (Panel? Guest speaker? Forum? Roundtable?)
+
+## Contacts for event planning
+* Lauren: planning overall WWC events (including event collabs with other meetups); also adding event/viewing access to WWC general Meetup calendar to avoid event clashes
+* Su: finding hosts for the event
+* Pam: coordinating general "Tech Talk Thursday" events
+ * Good topics for these types of events include things that mix front end tech with other types of tech (ie React Native, Clojurescript, etc.)
+
+## Responsibilities during event
+* Photos
+* Video (if requested by host or other sponsor; unable to do streaming)
+* Twitter: for live tweeting the event

--- a/events/hosts.md
+++ b/events/hosts.md
@@ -4,7 +4,7 @@ Su Kim schedules the time and location of each event, but each Front End Lab lea
 
 Front End Lab is always from 6:30 pm to 8:30 pm every Monday, except holidays.
 
-Due to privacy concerns, contact Su Kim for host contact (e.g. name, cellphone number), building access policy, and refreshments information. Do not publish on Github. 
+Due to privacy concerns, contact Su Kim for host contact (e.g. name, cellphone number), building access policy, and refreshments information. Do not publish on Github.
 
 ## First Monday
 * Company: [iStrategy Labs, Inc.](https://isl.co/)
@@ -20,10 +20,7 @@ Due to privacy concerns, contact Su Kim for host contact (e.g. name, cellphone n
 * Rough capacity: 200+
 
 ## Third Monday
-* Company: [ECMC Innovation Lab](http://www.idealist.org/view/nonprofit/Dg9NCGNZpcH4/)
-* Address: 1015 7th St NW, Washington, DC 20001
-* Closest Metro: Mount Vernon Square (Green/Yellow)
-* Rough capacity: 30+
+* Searching for third host
 
 ## Fourth Monday
 * Company: [Socrata](https://www.socrata.com/)
@@ -31,9 +28,8 @@ Due to privacy concerns, contact Su Kim for host contact (e.g. name, cellphone n
 * Closest Metro: Dupont Circle (Red)
 
 ## Fifth Monday
-Some months will have a fifth Monday - check each month and schedule these well in advance in order to avoid being surprised. Our usual fifth night host is RepEquity.
+Some months will have a fifth Monday - check each month and schedule these well in advance in order to avoid being surprised. Our usual fifth night host is Deloitte Digital.
 
-* Company: [RepEquity](http://www.repequity.com/)
-* Address: 1211 Connecticut Ave NW Suite 250, Washington, DC 20036
-* Closest Metro: Dupont Circle (Red) or Farragut North (Red)
-* Rough capacity: 60+
+* Company: [Deloitte Digital](http://www.deloittedigital.com/us/)
+* Address: 1919 N. Lynn Street Arlington, VA 22209
+* Closest Metro: Rosslyn (Orange/Silver/Blue)

--- a/events/onboarding.md
+++ b/events/onboarding.md
@@ -4,7 +4,7 @@ This is a checklist of what every lead should know/have access to for every Fron
 * Slack - Make an admin; grant access to the following channels
  * All Leads
  * Study Group Leads
- * Front End Hack Night Leads
+ * Front End Lab Leads
 * Google Drive
 * WWCDC email + password: wwcodedc@gmail.com
 * Welcome email to hosts for logistics
@@ -29,6 +29,6 @@ Announce on:
  * Post a comment in meetup for everybody about logistics
 * Google sheet with all the codeshares
  * add all the existing ones
-* Document FEHN Standard Operating Procedure
+* Document FEL Standard Operating Procedure
 * Important Documents
  * First Timer’s Guides: HTML/CSS


### PR DESCRIPTION
* Updated event information based on recent leads meeting (4/30)
* Removed ECMC as third Monday host
* Revised Deloitte Digital as (unofficial) fifth Monday host

Connects #13 